### PR TITLE
Style: Move main product section up slightly

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
       position: relative;
       z-index: 1;
       padding: 15px;
-      padding-top: 70px;
+      padding-top: 40px;
       padding-bottom: 70px;
       margin-left: 340px; /* Adjusted to account for the menu width + padding */
     }
@@ -600,7 +600,7 @@
       }
       .main-content {
         padding: 10px;
-        padding-top: 120px; /* Increased to account for the navigation menu height */
+        padding-top: 90px; /* Increased to account for the navigation menu height */
         padding-bottom: 80px;
         margin-left: 0; /* Remove margin on small screens */
       }


### PR DESCRIPTION
Reduces the top padding for the .main-content class in index.html to move the product image, information, and related quotes higher on the page.

- Desktop: padding-top changed from 70px to 40px.
- Mobile: padding-top changed from 120px to 90px.