### PR TITLE
Refactor: Update carousel to arrow-only nav, new arrow style, and fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
       width: 100%; /* This will take the width of its container, .main-content */
       max-width: 500px; /* To match the original max-width of content-wrapper, ensuring the viewport is not too wide */
       margin: 0 auto; /* To keep it centered like the original content-wrapper was */
-      cursor: grab; /* Add grab cursor for draggable items */
+      /* cursor: grab; -- Removed to disable drag cursor */
     }
     .product-carousel-slider {
       display: flex;
@@ -175,15 +175,16 @@
       flex-shrink: 0;
       width: 100%; /* Each slide takes the full width of the viewport */
       box-sizing: border-box; /* Ensure padding/border don't expand its width in flex context */
+      overflow: hidden; /* Prevent internal content from causing slides to appear wider */
     }
     .carousel-arrow {
       position: absolute;
-      top: 50%;
+      top: 45%; /* Changed from 50% */
       transform: translateY(-50%);
       z-index: 2;
-      background-color: rgba(0, 0, 0, 0.5);
-      color: white;
-      border: none;
+      background-color: transparent; /* Changed */
+      color: #8f00ff; /* Changed */
+      border: 1px solid #8f00ff; /* Changed */
       padding: 10px 15px;
       font-size: 24px;
       cursor: pointer;
@@ -192,7 +193,7 @@
       transition: background-color 0.3s ease;
     }
     .carousel-arrow:hover {
-      background-color: rgba(0, 0, 0, 0.8);
+      background-color: rgba(143, 0, 255, 0.1); /* Adjusted hover */
     }
     .carousel-arrow-prev {
       left: 10px;
@@ -1356,21 +1357,21 @@
       const prevButton = document.getElementById('carouselArrowPrev');
       const nextButton = document.getElementById('carouselArrowNext');
       let currentIndex = 0;
-      let isDragging = false;
-      let startX = 0;
-      let currentTranslate = 0;
-      let prevTranslate = 0;
-      let animationFrameId = null; // For requestAnimationFrame
+      // let isDragging = false; // Removed for drag functionality
+      // let startX = 0; // Removed for drag functionality
+      // let currentTranslate = 0; // Kept for setSliderPosition, but might be simplified later
+      // let prevTranslate = 0; // Removed for drag functionality
+      // let animationFrameId = null; // Removed for drag functionality
 
-      function getPositionX(event) {
-        return event.type.includes('mouse') ? event.pageX : event.touches[0].clientX;
-      }
+      // function getPositionX(event) { // Removed for drag functionality
+      //   return event.type.includes('mouse') ? event.pageX : event.touches[0].clientX;
+      // }
 
       function setSliderPosition() {
         if (slides.length === 0) return;
         const slideWidth = slides[0].offsetWidth;
-        currentTranslate = -currentIndex * slideWidth;
-        slider.style.transform = `translateX(${currentTranslate}px)`;
+        // currentTranslate = -currentIndex * slideWidth; // Direct calculation is fine
+        slider.style.transform = `translateX(${-currentIndex * slideWidth}px)`;
       }
 
       // Initialize slider position
@@ -1397,53 +1398,44 @@
         }
       }
 
-      function dragStart(event) {
-        isDragging = true;
-        startX = getPositionX(event);
-        prevTranslate = currentTranslate; // Store the current position before drag starts
-        carouselViewport.style.cursor = 'grabbing';
-        slider.style.transition = 'none'; // Disable transition during drag for smoother movement
+      // function dragStart(event) { // Removed for drag functionality
+      //   isDragging = true;
+      //   startX = getPositionX(event);
+      //   prevTranslate = currentTranslate; 
+      //   carouselViewport.style.cursor = 'grabbing';
+      //   slider.style.transition = 'none'; 
+      //   if (event.type.includes('mouse')) {
+      //     event.preventDefault(); 
+      //   }
+      // }
 
-        // Prevent default drag behavior and text selection
-        if (event.type.includes('mouse')) {
-          event.preventDefault(); // Prevents image dragging etc.
-        }
-      }
+      // function dragMove(event) { // Removed for drag functionality
+      //   if (isDragging) {
+      //     const currentX = getPositionX(event);
+      //     const diffX = currentX - startX;
+      //     slider.style.transform = `translateX(${prevTranslate + diffX}px)`;
+      //   }
+      // }
 
-      function dragMove(event) {
-        if (isDragging) {
-          const currentX = getPositionX(event);
-          const diffX = currentX - startX;
-          // Update slider position directly based on drag difference from the start of the drag
-          slider.style.transform = `translateX(${prevTranslate + diffX}px)`;
-        }
-      }
-
-      function dragEnd(event) {
-        if (!isDragging) return;
-        isDragging = false;
-        carouselViewport.style.cursor = 'grab';
-        slider.style.transition = 'transform 0.3s ease-in-out'; // Re-enable transition
-
-        const currentX = getPositionX(event);
-        const movedBy = currentX - startX; // Total distance moved during the drag
-        const slideWidth = slides[0].offsetWidth;
-        const threshold = slideWidth / 4; // Swipe threshold
-
-        // Determine if it was a swipe or just a small drag/click
-        if (Math.abs(movedBy) > threshold) {
-          if (movedBy < 0 && currentIndex < slides.length - 1) {
-            // Swiped left
-            currentIndex++;
-          } else if (movedBy > 0 && currentIndex > 0) {
-            // Swiped right
-            currentIndex--;
-          }
-        }
-        // Snap to the determined slide
-        setSliderPosition();
-        updateArrowVisibility(); // Call after drag/swipe
-      }
+      // function dragEnd(event) { // Removed for drag functionality
+      //   if (!isDragging) return;
+      //   isDragging = false;
+      //   carouselViewport.style.cursor = 'grab';
+      //   slider.style.transition = 'transform 0.3s ease-in-out'; 
+      //   const currentX = getPositionX(event);
+      //   const movedBy = currentX - startX; 
+      //   const slideWidth = slides[0].offsetWidth;
+      //   const threshold = slideWidth / 4; 
+      //   if (Math.abs(movedBy) > threshold) {
+      //     if (movedBy < 0 && currentIndex < slides.length - 1) {
+      //       currentIndex++;
+      //     } else if (movedBy > 0 && currentIndex > 0) {
+      //       currentIndex--;
+      //     }
+      //   }
+      //   setSliderPosition();
+      //   updateArrowVisibility(); 
+      // }
 
       // Arrow button event listeners
       if (prevButton) {
@@ -1466,25 +1458,25 @@
         });
       }
 
-      // Touch events
-      carouselViewport.addEventListener('touchstart', dragStart, { passive: true }); // passive:true for performance if not preventing default
-      carouselViewport.addEventListener('touchmove', (event) => {
-        if (isDragging) {
-          event.preventDefault(); // Prevent page scroll while swiping horizontally
-          dragMove(event);
-        }
-      });
-      carouselViewport.addEventListener('touchend', dragEnd);
+      // Touch events -- Removed for drag functionality
+      // carouselViewport.addEventListener('touchstart', dragStart, { passive: true }); 
+      // carouselViewport.addEventListener('touchmove', (event) => {
+      //   if (isDragging) {
+      //     event.preventDefault(); 
+      //     dragMove(event);
+      //   }
+      // });
+      // carouselViewport.addEventListener('touchend', dragEnd);
 
-      // Mouse events
-      carouselViewport.addEventListener('mousedown', dragStart);
-      carouselViewport.addEventListener('mousemove', dragMove);
-      carouselViewport.addEventListener('mouseup', dragEnd);
-      carouselViewport.addEventListener('mouseleave', () => {
-        if (isDragging) {
-          dragEnd({ pageX: startX }); // Simulate drag end if mouse leaves while dragging
-        }
-      });
+      // Mouse events -- Removed for drag functionality
+      // carouselViewport.addEventListener('mousedown', dragStart);
+      // carouselViewport.addEventListener('mousemove', dragMove);
+      // carouselViewport.addEventListener('mouseup', dragEnd);
+      // carouselViewport.addEventListener('mouseleave', () => {
+      //   if (isDragging) {
+      //     dragEnd({ pageX: startX }); 
+      //   }
+      // });
       
       // Recalculate on resize
       window.addEventListener('resize', setSliderPosition);


### PR DESCRIPTION
This commit refactors the product carousel based on your feedback:
1.  Removes swipe and mouse-drag functionality. Navigation is now exclusively through arrow buttons.
2.  Updates navigation arrow styling:
    - Color changed to match the mute button (transparent background, #8f00ff border/icon).
    - Vertical position adjusted slightly higher (top: 45%).
    - Hover effect updated to complement the new style.
3.  Fixes a visual issue where a portion of the next/previous slide could be seen ('peeking'). Added `overflow: hidden` to individual slide elements to resolve this.

All associated JavaScript event listeners, handler functions, and CSS related to swipe/drag have been removed or commented out. The carousel remains responsive, and arrow visibility is correctly handled at boundaries.