### PR TITLE
Style: Reposition carousel arrows further out on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -839,6 +839,16 @@
       white-space: pre-wrap;
       word-break: break-all;
     }
+
+    @media (min-width: 769px) {
+      /* Desktop specific arrow positioning */
+      .carousel-arrow-prev {
+        left: -30px; /* Moves the previous arrow further to the left */
+      }
+      .carousel-arrow-next {
+        right: -30px; /* Moves the next arrow further to the right */
+      }
+    }
     
   </style>
 </head>


### PR DESCRIPTION
This commit adjusts the horizontal positioning of the carousel navigation arrows specifically for desktop view to reduce overlap with the main content.

- Added a `@media (min-width: 769px)` query.
- Within this query, `.carousel-arrow-prev` is set to `left: -30px` and `.carousel-arrow-next` is set to `right: -30px`.

This positions the arrows outside the carousel's main content box on desktop screens, while mobile screens retain the previous `left: 5px` and `right: 5px` positioning.