### PR TITLE
Style: Position desktop carousel arrows at viewport edges

### DIFF
--- a/index.html
+++ b/index.html
@@ -843,10 +843,10 @@
     @media (min-width: 769px) {
       /* Desktop specific arrow positioning */
       .carousel-arrow-prev {
-        left: -30px; /* Moves the previous arrow further to the left */
+        left: 0px; /* Position flush with the left edge of the viewport */
       }
       .carousel-arrow-next {
-        right: -30px; /* Moves the next arrow further to the right */
+        right: 0px; /* Position flush with the right edge of the viewport */
       }
     }
     


### PR DESCRIPTION
This commit adjusts the horizontal positioning of the carousel navigation arrows on desktop to prevent them from being cut off by the viewport's `overflow: hidden` property and to further reduce overlap with slide content.

- Within the `@media (min-width: 769px)` CSS rule:
    - `.carousel-arrow-prev` is set to `left: 0px;`
    - `.carousel-arrow-next` is set to `right: 0px;`

This places the arrows flush with the absolute edges of the carousel viewport on desktop screens. Mobile styling for arrows remains unchanged (at `5px` from edges).