### PR TITLE
feat: Update main page VR button and refine VR experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -919,26 +919,54 @@
     @keyframes rightDown { 50% { top: 4px; left: 16px; } 100% { top: 12px; left: 24px; } }
     @keyframes drop { 100% { transform: translate(70px, 150px); } } /* Simplified drop Y value */
     
-    #enterVRButton {
+    #goggleLinkToVR {
       position: fixed;
       left: 20px;
-      bottom: 60px;  /* Adjusted from 70px to ensure it's just above a typical footer height */
+      bottom: 80px; /* Positioned higher */
       z-index: 1000;
-      padding: 10px 15px;
-      background-color: #8f00ff; /* Purple, consistent with theme */
-      color: #ffffff;
-      border: none;
-      border-radius: 5px;
+      display: block;
+      width: 50px; /* Adjust size as needed */
+      height: 35px; /* Adjust size as needed */
+      text-decoration: none;
       cursor: pointer;
-      font-family: 'Orbitron', sans-serif; /* Consistent with game menu */
-      font-size: 0.9rem; /* Added for better text scaling */
-      box-shadow: 0 0 10px #8f00ff, 0 0 15px #8f00ff66; /* Added glow effect */
-      transition: background-color 0.3s ease, box-shadow 0.3s ease; /* Smooth transition */
+      transition: transform 0.2s ease-out;
     }
 
-    #enterVRButton:hover {
-      background-color: #a033ff; /* Lighter purple */
-      box-shadow: 0 0 15px #a033ff, 0 0 20px #a033ff66; /* Enhanced glow on hover */
+    #goggleLinkToVR:hover {
+      transform: scale(1.1);
+    }
+
+    #goggleIcon {
+      display: block;
+      width: 100%;
+      height: 100%;
+      background-color: #555; /* Dark grey for goggles */
+      border-radius: 15px 15px 25px 25px / 15px 15px 30px 30px; /* Goggle shape */
+      position: relative;
+      box-shadow: 0 0 10px rgba(143, 0, 255, 0.7), 0 0 5px rgba(204, 0, 255, 0.5); /* Subtle purple glow */
+      overflow: hidden; /* To contain pseudo-elements if needed for lenses */
+    }
+
+    /* Lenses (simplified) */
+    #goggleIcon::before,
+    #goggleIcon::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 12px; /* Lens width */
+      height: 12px; /* Lens height */
+      background-color: #222; /* Darker lens color */
+      border-radius: 50%;
+      border: 1px solid #777;
+    }
+
+    #goggleIcon::before {
+      left: 7px; /* Position for left lens */
+    }
+
+    #goggleIcon::after {
+      right: 7px; /* Position for right lens */
     }
   </style>
 </head>
@@ -1050,7 +1078,9 @@
     </div>
   </div>
 
-  <button id="enterVRButton" onclick="window.location.href='vr-experience.html'">ENTER VR</button>
+  <a href="vr-experience.html" id="goggleLinkToVR" aria-label="Enter VR Experience">
+    <span id="goggleIcon"></span>
+  </a>
   <footer class="footer">
     <div class="secure-copyright">
       <div class="copyright">© 2025 BlackHoles.Store. All rights reserved.</div>

--- a/vr-experience.html
+++ b/vr-experience.html
@@ -22,8 +22,8 @@
       </a-camera>
       <a-entity id="leftHand" meta-quest-touch-controls="hand: left"></a-entity>
       <a-entity id="rightHand" meta-quest-touch-controls="hand: right"></a-entity>
-      <a-entity id="leftHandVisual" hand-tracking-controls="hand: left; modelStyle: highPoly; modelColor: #ffdbac;"></a-entity>
-      <a-entity id="rightHandVisual" hand-tracking-controls="hand: right; modelStyle: highPoly; modelColor: #ffdbac;"></a-entity>
+      <a-entity id="leftHandVisual" hand-tracking-controls="hand: left; modelStyle: basic; modelColor: #ffdbac;"></a-entity>
+      <a-entity id="rightHandVisual" hand-tracking-controls="hand: right; modelStyle: basic; modelColor: #ffdbac;"></a-entity>
     </a-entity>
 
     <!-- Scene content (torus, text, sound) -->


### PR DESCRIPTION
Updates `index.html`:
- Replaces the previous custom 'ENTER VR' button with a new custom button styled to resemble a VR goggle icon.
- Positions this new button higher (bottom: 80px) to prevent overlap with the footer.
- This button continues to navigate to `vr-experience.html`.

Updates `vr-experience.html`:
- Simplifies hand tracking models (`modelStyle: 'basic'`) for `hand-tracking-controls` to improve reliability of visualization.
- Confirms `meta-quest-touch-controls` are in place for controller visualization.
- Verifies `vr-mode-ui="enabled: true"` is set for the scene, pending your testing for 'Exit VR' UI visibility on Quest 3.
- (Includes previously committed raw sound URL fix for this page).